### PR TITLE
fix(helm): right-size the UI CPU request, 500m -> 50m

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -33,7 +33,23 @@ snapagogo:
       - www.snapagogo.app
       - snapagogo.app
     resources:
-      cpu: 500m
+      # 500m was requested here and the pod uses 1m: it serves static assets,
+      # so the request was ~500x its actual draw. On a dev cluster whose two
+      # regular nodes sit at 97% and 99% of requested CPU, that reservation is
+      # what blocked other workloads from scheduling at all (the autoscaler is
+      # already at max node group size, so nothing can be added to absorb it).
+      #
+      # `cpu` is templated as a REQUEST only — deployment-ui.yaml sets no CPU
+      # limit — so this changes what the scheduler reserves, not what the
+      # container may burst to. 50m still leaves ~50x headroom over measured
+      # usage.
+      #
+      # Measured 2026-09-02 via `kubectl top pod -n snapagogo`:
+      #   snapagogo-ui  1m CPU  8Mi memory
+      cpu: 50m
+      # Memory left at 256M deliberately. Usage is 8Mi, so this is also
+      # oversized, but memory was not the binding constraint and trimming a
+      # request with no limit set risks an OOM kill under an unmeasured spike.
       memory: 256M
       memorylimit: false
 


### PR DESCRIPTION
The UI requested 500m CPU and uses 1m. It serves static assets, so the
reservation was roughly 500x its actual draw.

Measured 2026-09-02, `kubectl top pod -n snapagogo` on dev-cluster:

  snapagogo-api   3m CPU   1665Mi
  snapagogo-db    3m CPU    515Mi
  snapagogo-ui    1m CPU      8Mi   <- requests 500m

That reservation had a cost outside this chart. Both regular (ontopooldef)
nodes on that cluster sit at 97% and 99% of requested CPU — 7518m of 7720m
across 69 pods — and the cluster autoscaler is already at max node group
size, so nothing can be added to absorb it. A code-search pod requesting
100m could not be scheduled at all: ~80m was free where 100m was needed.
Releasing 450m here clears that with room to spare.

`cpu` is templated as a REQUEST only — `deployment-ui.yaml` sets no CPU
limit, only a conditional memory one — so this changes what the scheduler
reserves, not what the container may burst to. Under contention the UI
gets a smaller guaranteed share; at 1m against a 50m request that is not
a real exposure.

Memory left at 256M deliberately. It is also oversized against 8Mi, but
memory was not the binding constraint and trimming a request whose limit
is disabled (`memorylimit: false`) risks an OOM kill on an unmeasured
spike. Not worth pairing with an urgent capacity fix.

The API's 500m is untouched: it is a Spring service with a 2g heap and its
own 3Gi memory limit, and nothing here measured it as oversized.

Verified: `helm template helm` renders the API block unchanged and the UI
as `requests: {cpu: 50m, memory: 256M}` with no limits. The only
functional line changed is the one value.